### PR TITLE
Osx support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,26 @@ https://github.com/karulis/pybluez
 - Widcomm BTW development kit 5.0 or later (Optional)
 - Python 2.3 or more recent version
 
+*Mac OS X (Tested only on OS X 10.10)*:
+
+- Python 2.3 or later.
+- Xcode
+- PyObjc 3.0.4 or later (https://pythonhosted.org/pyobjc/install.html)
+
+```
+$ brew install hg  # If you don't have hg already.
+$ hg clone https://bitbucket.org/ronaldoussoren/pyobjc
+$ cd pyobjc/
+$ sudo python install.py
+```
+- PyBluez: https://github.com/karulis/pybluezs
+
+```
+$ git clone https://github.com/karulis/pybluez.git
+$ cd pybluez
+$ python setup.py install  # <-- you may need to use 'sudo'
+```
+
 **INSTALLATION:**
 
 from a command shell:

--- a/README.rst
+++ b/README.rst
@@ -29,19 +29,20 @@ https://github.com/karulis/pybluez
 - Xcode
 - PyObjc 3.0.4 or later (https://pythonhosted.org/pyobjc/install.html)
 
-```
-$ brew install hg  # If you don't have hg already.
-$ hg clone https://bitbucket.org/ronaldoussoren/pyobjc
-$ cd pyobjc/
-$ sudo python install.py
-```
-- PyBluez: https://github.com/karulis/pybluezs
+.. code-block:: python
 
-```
-$ git clone https://github.com/karulis/pybluez.git
-$ cd pybluez
-$ python setup.py install  # <-- you may need to use 'sudo'
-```
+    $ brew install hg  # If you don't have hg already.
+    $ hg clone https://bitbucket.org/ronaldoussoren/pyobjc
+    $ cd pyobjc/
+    $ sudo python install.py
+
+- PyBluez: https://github.com/karulis/pybluez
+
+.. code-block:: python
+
+    $ git clone https://github.com/karulis/pybluez.git
+    $ cd pybluez
+    $ python setup.py install  # <-- you may need to use 'sudo'
 
 **INSTALLATION:**
 

--- a/bluetooth/osx.py
+++ b/bluetooth/osx.py
@@ -4,10 +4,6 @@
 import lightblue
 from .btcommon import *
 
-def lookup_name(address, timeout=10):
-    print "TODO: implement"
-
-
 def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
     # This is order of discovered device attributes in C-code.
     btAddresIndex = 0
@@ -30,6 +26,9 @@ def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_cl
         else:
             ret.append(tuple(i for i in item))
     return ret
+
+def lookup_name(address, timeout=10):
+    print "TODO: implement"
 
 def find_service(name=None, uuid=None, address=None):
     if uuid:

--- a/bluetooth/osx.py
+++ b/bluetooth/osx.py
@@ -1,3 +1,97 @@
+# OLD:
+
+# from .btcommon import *
+
+# raise NotImplementedError
+
+################################################################################
+
+####################################
+# MINIMAL IMPLEMENTATION OF osx.py:
+####################################
+
+import lightblue
 from .btcommon import *
 
-raise NotImplementedError
+def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
+    return lightblue.finddevices(getnames=lookup_names, length=duration)
+
+def find_service(name=None, uuid=None, address=None):
+    if uuid:
+        raise NotImplementedError("UUID argument is not supported on OS X.")
+    return lightblue.findservices(addr=address, name=name)
+
+################################################################################
+
+# import lightblue
+# from .btcommon import *
+
+# class BluetoothSocket:
+    
+#     def __init__ (self, proto=RFCOMM, _sock=None):
+#         if _sock is None:
+#             _sock = lightblue.socket()
+#         self._sock = _sock
+
+#         if proto != RFCOMM:
+#             raise NotImplementedError("Not supported protocol") ### name the protocol
+#         self._proto = proto
+
+#     def bind(self, addrport):
+#         return self._sock.bind(addrport)
+
+#     def listen(self, backlog):
+#         return self._sock.listen(backlog)
+
+#     def accept(self):
+#         return self._sock.accept()
+
+#     def connect(self, addrport):
+#         return self._sock.connect(addrport)
+
+#     def send(self, data):
+#         return self._sock.send(data)
+
+#     def recv(self, numbytes):
+#         return self._sock.recv(numbytes)
+
+#     def close(self):
+#         return self._sock.close()
+
+#     def getsockname(self):
+#         return self._sock.getsockname()
+
+#     def setblocking(self, blocking):
+#         return self._sock.setblocking(blocking)
+
+#     def settimeout(self, timeout):
+#         return self._sock.settimeout(timeout)
+
+#     def gettimeout(self):
+#         return self._sock.gettimeout()
+
+#     def fileno(self):
+#         return self._sock.fileno()
+
+#     def dup(self):
+#         return BluetoothSocket(self._proto, self._sock)
+
+#     def makefile(self, mode, bufsize):
+#         return self.makefile(mode, bufsize)
+
+# # THIS HEADER IS BAD -- SHOULD NOT INIT VAR. TO [] IN HEADER DEFINITION -- WILL GET WEIRD BUGS.....
+# #def advertise_service(sock, name, service_id = "", service_class = [], profiles = [], provider = "", description = "", protocols = []):
+# def advertise_service(sock, name, service_id = "", service_class = None, profiles = None, provider = "", description = "", protocols = None):
+#     lightblue.advertise(name, sock, protocols[0])
+
+# def stop_advertise(sock):
+#     lightblue.stopadvertise(sock)
+
+# def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
+#     return lightblue.finddevices(getnames=lookup_names, length=duration)
+
+# def find_service(name=None, uuid=None, address=None):
+#     if uuid:
+#         raise NotImplementedError("UUID argument is not supported on OS X.")
+#     return lightblue.findservices(addr=address, name=name)
+

--- a/bluetooth/osx.py
+++ b/bluetooth/osx.py
@@ -1,20 +1,35 @@
-# OLD:
-
-# from .btcommon import *
-
-# raise NotImplementedError
-
-################################################################################
-
 ####################################
 # MINIMAL IMPLEMENTATION OF osx.py:
 ####################################
-
 import lightblue
 from .btcommon import *
 
+def lookup_name(address, timeout=10):
+    print "TODO: implement"
+
+
 def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
-    return lightblue.finddevices(getnames=lookup_names, length=duration)
+    # This is order of discovered device attributes in C-code.
+    btAddresIndex = 0
+    namesIndex = 1
+    classIndex = 2
+
+    # Use lightblue to discover devices on OSX.
+    devices = lightblue.finddevices(getnames=lookup_names, length=duration)
+
+    ret = list()
+    for device in devices:
+        item = [device[btAddresIndex],]
+        if lookup_names:
+            item.append(device[namesIndex])
+        if lookup_class:
+            item.append(device[classIndex])
+
+        if len(item) == 1: # in case of address-only we return string not tuple
+            ret.append(item[0])
+        else:
+            ret.append(tuple(i for i in item))
+    return ret
 
 def find_service(name=None, uuid=None, address=None):
     if uuid:
@@ -81,17 +96,24 @@ def find_service(name=None, uuid=None, address=None):
 
 # # THIS HEADER IS BAD -- SHOULD NOT INIT VAR. TO [] IN HEADER DEFINITION -- WILL GET WEIRD BUGS.....
 # #def advertise_service(sock, name, service_id = "", service_class = [], profiles = [], provider = "", description = "", protocols = []):
-# def advertise_service(sock, name, service_id = "", service_class = None, profiles = None, provider = "", description = "", protocols = None):
-#     lightblue.advertise(name, sock, protocols[0])
+def advertise_service(sock, name, service_id="", service_class=None, profiles=None, provider="", description="", protocols=None):
+    if service_class is None:
+        service_class = []
+    if profiles is None:
+        profiles = []
+    if protocols is None:
+        protocols = []
 
-# def stop_advertise(sock):
-#     lightblue.stopadvertise(sock)
+    lightblue.advertise(name, sock, protocols[0])
+
+def stop_advertising(sock):
+    lightblue.stop_advertising(sock)
 
 # def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
 #     return lightblue.finddevices(getnames=lookup_names, length=duration)
 
-# def find_service(name=None, uuid=None, address=None):
-#     if uuid:
-#         raise NotImplementedError("UUID argument is not supported on OS X.")
-#     return lightblue.findservices(addr=address, name=name)
+def find_service(name=None, uuid=None, address=None):
+    if uuid:
+        raise NotImplementedError("UUID argument is not supported on OS X.")
+    return lightblue.findservices(addr=address, name=name)
 

--- a/bluetooth/osx.py
+++ b/bluetooth/osx.py
@@ -1,8 +1,6 @@
 import lightblue
 from .btcommon import *
 
-BLUETOOTH_INSTALL_FLAG = 3
-
 def discover_devices(duration=8, flush_cache=True, lookup_names=False, lookup_class=False, device_id=-1):
     # This is order of discovered device attributes in C-code.
     btAddresIndex = 0
@@ -71,6 +69,10 @@ def find_service(name=None, uuid=None, address=None):
 
     return results
 
+def read_local_bdaddr():
+    # NOTE: This function is only supported on osx.
+    return lightblue.gethostaddr()
+
 # THIS HEADER IS BAD -- SHOULD NOT INIT VAR. TO [] IN HEADER DEFINITION -- WILL GET WEIRD BUGS.....
 #def advertise_service(sock, name, service_id = "", service_class = [], profiles = [], provider = "", description = "", protocols = []):
 def advertise_service(sock, name, service_id="", service_class=None, profiles=None, provider="", description="", protocols=None):
@@ -85,6 +87,7 @@ def advertise_service(sock, name, service_id="", service_class=None, profiles=No
 
 def stop_advertising(sock):
     lightblue.stop_advertising(sock)
+
 
 # ============================= BluetoothSocket ============================== #
 

--- a/examples/advanced/read-local-bdaddr.py
+++ b/examples/advanced/read-local-bdaddr.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import struct
-import bluetooth._bluetooth as _bt
 
 if sys.version < '3':
     get_byte = str
@@ -35,7 +34,15 @@ def read_local_bdaddr(hci_sock):
     return bdaddr
 
 if __name__ == "__main__":
-    dev_id = 0
-    hci_sock = _bt.hci_open_dev(dev_id)
-    bdaddr = read_local_bdaddr(hci_sock)
+    if sys.platform.startswith("darwin"):
+        # On OSX, lightblue uses the LightAquaBlue framework to access
+        # information about the local bluetooth device.
+        import bluetooth
+        bdaddr = bluetooth.read_local_bdaddr()
+    else:
+        import bluetooth._bluetooth as _bt
+        dev_id = 0
+        hci_sock = _bt.hci_open_dev(dev_id)
+        bdaddr = read_local_bdaddr(hci_sock)
+
     print(bdaddr)

--- a/examples/simple/sdp-browse.py
+++ b/examples/simple/sdp-browse.py
@@ -18,7 +18,7 @@ services = bluetooth.find_service(address=target)
 
 if len(services) > 0:
     print("found %d services on %s" % (len(services), sys.argv[1]))
-    print()
+    print("")
 else:
     print("no services found")
 
@@ -32,4 +32,4 @@ for svc in services:
     print("    svc classes: %s "% svc["service-classes"])
     print("    profiles:    %s "% svc["profiles"])
     print("    service id:  %s "% svc["service-id"])
-    print()
+    print("")

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,9 @@ mods = []
 
 def getpackagedir():
     if WIN32:
-        return "TODO" #"src/win"
+        return "TODO" #"src/win" -- piotrek can you address this?
     elif LINUX:
-        return "TODO" #"src/linux"
+        return "TODO" #"src/linux"  -- piotrek can you address this?
     elif MAC:
         return "osx"
     else:
@@ -131,10 +131,8 @@ setup ( name = 'PyBluez',
         url="http://karulis.github.io/pybluez/",
         ext_modules = mods,
         packages = [ "bluetooth", "lightblue" ],
-        package_dir = { 'lightblue': 'osx' }, 
-        # packages = [ "bluetooth", "lightblue" ],
-        # package_dir = { 'lightblue': getpackagedir() }, 
-# for the python cheese shop
+        package_dir = { 'lightblue': getpackagedir() }, 
+        # for the python cheese shop
         classifiers = [ 'Development Status :: 4 - Beta',
             'License :: OSI Approved :: GNU General Public License (GPL)',
             'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,21 @@ import sys
 import platform
 import os
 
+WIN32 = sys.platform.startswith("win32")
+LINUX = sys.platform.startswith("linux")
+MAC   = sys.platform.startswith("darwin")
+
 mods = []
+
+def getpackagedir():
+    if WIN32:
+        return "TODO" #"src/win"
+    elif LINUX:
+        return "TODO" #"src/linux"
+    elif MAC:
+        return "osx"
+    else:
+        raise Exception("Unsupported platform")
 
 def find_MS_SDK():
     candidate_roots = (os.getenv('ProgramFiles'), os.getenv('ProgramW6432'),
@@ -116,7 +130,10 @@ setup ( name = 'PyBluez',
         author_email="ashuang@alum.mit.edu",
         url="http://karulis.github.io/pybluez/",
         ext_modules = mods,
-        packages = [ "bluetooth" ],
+        packages = [ "bluetooth", "lightblue" ],
+        package_dir = { 'lightblue': 'osx' }, 
+        # packages = [ "bluetooth", "lightblue" ],
+        # package_dir = { 'lightblue': getpackagedir() }, 
 # for the python cheese shop
         classifiers = [ 'Development Status :: 4 - Beta',
             'License :: OSI Approved :: GNU General Public License (GPL)',


### PR DESCRIPTION
- Updated setup.py to install LightAquaBlue framework (for bluetooth use on osx) and to install the pybluez/lightblue projects correctly.
- Add basic support to osx.py; specifically, discover_devices() works (try inquiry.py). Other code is in progress and hasn't yet been verified.
