### PR TITLE
fix broken install on Windows / 2.7 / VS9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def find_MS_SDK():
 
     if sys.version < '3.3':
         MS_SDK = r'Microsoft SDKs\Windows\v6.0A'  # Visual Studio 9
-    if sys.version >= '3.5':
+    elif sys.version >= '3.5':
         MS_SDK = r'Microsoft SDKs\Windows\v10.0A'  # Visual Studio 14
     else:
         MS_SDK = r'Microsoft SDKs\Windows\v7.0A'  # Visual Studio 10

--- a/setup.py
+++ b/setup.py
@@ -15,10 +15,10 @@ def find_MS_SDK():
 
     if sys.version < '3.3':
         MS_SDK = r'Microsoft SDKs\Windows\v6.0A'  # Visual Studio 9
+    elif '3.3' <= sys.version < '3.5':
+        MS_SDK = r'Microsoft SDKs\Windows\v7.0A'  # Visual Studio 10
     elif sys.version >= '3.5':
         MS_SDK = r'Microsoft SDKs\Windows\v10.0A'  # Visual Studio 14
-    else:
-        MS_SDK = r'Microsoft SDKs\Windows\v7.0A'  # Visual Studio 10
 
     candidate_paths = (MS_SDK,
                        'Microsoft Platform SDK for Windows XP',


### PR DESCRIPTION
Install is broken if you use python <3.3 and Visual Studio 9 on Windows (regression introduced with b02e3121).
- install Visual Studio 9 (`C:\Program Files\Microsoft SDKs\Windows\v6.0A\`)
- install Python 2.7
- python setup.py install

> Could not find the Windows Platform SDK

```
$  git clone git@github.com:karulis/pybluez.git
Cloning into 'pybluez'...
remote: Counting objects: 1029, done.
emote: Total 1029 (delta 0), reused 0 (delta 0), pack-reused 1029R
Receiving objects: 100% (1029/1029), 389.54 KiB | 0 bytes/s, done.
Resolving deltas: 100% (632/632), done.
Checking connectivity... done.

Thomas@Thomas-PC MINGW64 /c/tmp
$  cd pybluez/

Thomas@Thomas-PC MINGW64 /c/tmp/pybluez (master)
$  git:(master) git show --oneline -s
c1b2fab Removed trailing white spaces

Thomas@Thomas-PC MINGW64 /c/tmp/pybluez (master)
$  git:(master) python
Python 2.7.11 (v2.7.11:6d1b6a68f775, Dec  5 2015, 20:32:19) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>>

Thomas@Thomas-PC MINGW64 /c/tmp/pybluez (master)
$  git:(master) file "C:/Program Files/Microsoft SDKs/Windows/v6.0A/"
C:/Program Files/Microsoft SDKs/Windows/v6.0A/: directory

Thomas@Thomas-PC MINGW64 /c/tmp/pybluez (master)
$  git:(master) python setup.py install
Could not find the Windows Platform SDK
```
