### PR TITLE
Fix : "Could not find the Windows Platform SDK" when using Visual C++…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ def find_MS_SDK():
 
     candidate_paths = (MS_SDK,
                        'Microsoft Platform SDK for Windows XP',
-                       'Microsoft Platform SDK')
+                       'Microsoft Platform SDK',
+                        'Common Files\Microsoft\Visual C++ for Python\9.0\WinSDK')
 
     for candidate_root in candidate_roots:
         for candidate_path in candidate_paths:


### PR DESCRIPTION
When using Python 2.7.11 on Windows and Visual C++ for Python as found at https://www.microsoft.com/en-us/download/details.aspx?id=44266 the `python setup.py install` fails with error 

> Could not find the Windows Platform SDK
