### PR TITLE
Fix error on Mac "objc.BadPrototypeError: Objective-C expects 1 arg..."

### DIFF
--- a/osx/_bluetoothsockets.py
+++ b/osx/_bluetoothsockets.py
@@ -819,6 +819,7 @@ class _ChannelEventListener(Foundation.NSObject):
     def delegate(self):
         return self.__channelDelegate
 
+    @objc.python_method
     def registerclosenotif(self, channel):
         # oddly enough, sometimes the channelClosed: selector doesn't get called
         # (maybe if there's a lot of data being passed?) but this seems to work

--- a/osx/_lightblue.py
+++ b/osx/_lightblue.py
@@ -285,6 +285,7 @@ class _SDPQueryRunner(Foundation.NSObject):
     on an IOBluetoothDevice.
     """
 
+    @objc.python_method
     def query(self, device, timeout=10.0):
         # do SDP query
         err = device.performSDPQuery_(self)
@@ -310,6 +311,7 @@ class _SDPQueryRunner(Foundation.NSObject):
     sdpQueryComplete_status_ = objc.selector(
         sdpQueryComplete_status_, signature=b"v@:@i")    # accept object, int
 
+    @objc.python_method
     def _errmsg(self, device):
         return "Error getting services for %s" % device.getNameOrAddress()
 
@@ -403,6 +405,7 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
         return self
 
     # length property
+    @objc.python_method
     def _setlength(self, length):
         self._inquiry.setInquiryLength_(length)
     length = property(
@@ -410,6 +413,7 @@ class _AsyncDeviceInquiry(Foundation.NSObject):
             _setlength)
 
     # updatenames property
+    @objc.python_method
     def _setupdatenames(self, update):
         self._inquiry.setUpdateNewDeviceNames_(update)
     updatenames = property(

--- a/osx/_macutil.py
+++ b/osx/_macutil.py
@@ -172,6 +172,7 @@ class BBCocoaSleeper(NSObject):
         self.timedout = False
         return self
 
+    @objc.python_method
     def sleep(self, timeout):
         NSTimer.scheduledTimerWithTimeInterval_target_selector_userInfo_repeats_(
                 timeout, self, "timedOut:", None, False)


### PR DESCRIPTION
Version 3.2 of PyObjC introduced a backwards incompatible change. Now methods that do not have a trailing slash need to be decorated with @objc.python_method. I've decorated only the methods that would preclude me from executing simple device discovery. Maybe more methods need to be decorated.

See the "Backward compatibility note" under Version 3.2
https://pythonhosted.org/pyobjc/core/changelog.html