### PR TITLE
Improve macOS compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,7 @@
 build/
 PyBluez.egg-info/
 dist/
+
+# Mac detritus 
+.DS_Store
+xcuserdata/

--- a/osx/LightAquaBlue/BBBluetoothOBEXClient.h
+++ b/osx/LightAquaBlue/BBBluetoothOBEXClient.h
@@ -264,7 +264,7 @@ didFinishPutRequestForStream:(NSInputStream *)inputStream
  * during a Put request. <length> is the number of bytes sent.
  */
 - (void)client:(BBBluetoothOBEXClient *)client
-  didSendDataOfLength:(unsigned)length;
+  didSendDataOfLength:(NSUInteger)length;
 
 /*
  * Called each time the client receives another chunk of data from the OBEX

--- a/osx/LightAquaBlue/BBBluetoothOBEXClient.m
+++ b/osx/LightAquaBlue/BBBluetoothOBEXClient.m
@@ -45,7 +45,7 @@ static BOOL _debug = NO;
 {
     self = [super init];
 
-    mSession = [[IOBluetoothOBEXSession alloc] initWithDevice:[IOBluetoothDevice withAddress:deviceAddress]
+    mSession = [[IOBluetoothOBEXSession alloc] initWithDevice:[IOBluetoothDevice deviceWithAddress:deviceAddress]
                                                     channelID:channelID];
     mDelegate = delegate;
 

--- a/osx/LightAquaBlue/BBBluetoothOBEXServer.h
+++ b/osx/LightAquaBlue/BBBluetoothOBEXServer.h
@@ -239,7 +239,7 @@ shouldHandlePutDeleteRequest:(BBOBEXHeaderSet *)requestHeaders;
  * The <length> indicates the number of bytes sent.
  */
 - (void)server:(BBBluetoothOBEXServer *)server
-didSendDataOfLength:(unsigned)length;
+didSendDataOfLength:(NSUInteger)length;
 
 /*
  * Called when the server finishes processing of a Get request. The

--- a/osx/LightAquaBlue/BBMutableOBEXHeaderSet.m
+++ b/osx/LightAquaBlue/BBMutableOBEXHeaderSet.m
@@ -206,8 +206,6 @@ static uint32_t parseUInt32(const uint8_t *bytes)
 
 static NSString *parseString(const uint8_t *bytes, unsigned int length)
 {
-    if (length < 0)
-        return nil;
 	NSString *s = [[NSString alloc] initWithBytes:bytes
 										   length:length
 										 encoding:NSUnicodeStringEncoding];
@@ -216,8 +214,6 @@ static NSString *parseString(const uint8_t *bytes, unsigned int length)
 
 static NSData *parseData(const uint8_t *bytes, unsigned int length)
 {
-    if (length < 0)
-        return nil;
     return [NSData dataWithBytes:bytes length:length];
 }
 

--- a/osx/LightAquaBlue/BBOBEXHeaderSet.h
+++ b/osx/LightAquaBlue/BBOBEXHeaderSet.h
@@ -52,7 +52,7 @@
 /*
  * Returns the number of headers in this header set.
  */
-- (unsigned)count;
+- (NSUInteger)count;
 
 /*
  * Returns the "Count" header value, or 0 if the header is not present or cannot

--- a/osx/LightAquaBlue/BBOBEXHeaderSet.m
+++ b/osx/LightAquaBlue/BBOBEXHeaderSet.m
@@ -279,7 +279,7 @@ static NSData *oneByteHeaderBytes(uint8_t hid, uint8_t value)
     NSMutableData *headerBytes = [[NSMutableData alloc] initWithLength:0];
 
     if ([self containsValueForHeader:kOBEXHeaderIDTarget]) {
-        NSData *bytes;
+        NSData *bytes = nil;
         NSData *target = [self valueForTargetHeader];
         if (target)
             bytes = byteSequenceHeaderBytes(kOBEXHeaderIDTarget, target);
@@ -345,7 +345,7 @@ static NSData *oneByteHeaderBytes(uint8_t hid, uint8_t value)
 	return headerBytes;
 }
 
-- (unsigned)count
+- (NSUInteger)count
 {
     return [mDict count];
 }

--- a/osx/LightAquaBlue/BBOBEXRequest.m
+++ b/osx/LightAquaBlue/BBOBEXRequest.m
@@ -104,7 +104,7 @@ static BOOL _debug = NO;
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXConnectRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXConnectRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
     CFMutableDataRef bytes = (CFMutableDataRef)[headers toBytes];
     if (!bytes && [headers count] > 0)
         return kOBEXInternalError;
@@ -164,7 +164,7 @@ static BOOL _debug = NO;
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXDisconnectRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXDisconnectRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
 
     CFMutableDataRef bytes = (CFMutableDataRef)[headers toBytes];
     if (!bytes && [headers count] > 0)
@@ -244,10 +244,10 @@ static BOOL _debug = NO;
 	OBEXMaxPacketLength maxBodySize = maxPacketSize - headersLength;
 
     NSMutableData *data = [NSMutableData dataWithLength:maxBodySize];
-    int len = [mInputStream read:[data mutableBytes]
+    NSInteger len = [mInputStream read:[data mutableBytes]
                        maxLength:maxBodySize];
 
-    if (_debug) NSLog(@"[BBOBEXPutRequest] read %d bytes (maxBodySize = %d)", len, maxBodySize);
+    if (_debug) NSLog(@"[BBOBEXPutRequest] read %ld bytes (maxBodySize = %d)", (long)len, maxBodySize);
 
     // is last packet if there wasn't enough body data to fill up the packet
     if (len >= 0)
@@ -285,7 +285,7 @@ static BOOL _debug = NO;
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXPutRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXPutRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
 
     // there's no stream if it's a Put-Delete
     // but if there is a stream, it must be open
@@ -442,7 +442,7 @@ static BOOL _debug = NO;
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXGetRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXGetRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
 
     if (mOutputStream == nil || [mOutputStream streamStatus] != NSStreamStatusOpen)
         return kOBEXBadArgumentError;
@@ -583,7 +583,7 @@ createDirectoriesIfNeeded:(BOOL)createDirectoriesIfNeeded
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXSetPathRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXSetPathRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
 
     CFMutableDataRef bytes = (CFMutableDataRef)[headers toBytes];
     if (!bytes && [headers count] > 0)
@@ -653,7 +653,7 @@ currentRequestStream:(NSStream *)stream
 
 - (OBEXError)beginWithHeaders:(BBOBEXHeaderSet *)headers
 {
-    if (_debug) NSLog(@"[BBOBEXAbortRequest] beginWithHeaders (%d headers)", [headers count]);
+    if (_debug) NSLog(@"[BBOBEXAbortRequest] beginWithHeaders (%lu headers)", (unsigned long)[headers count]);
 
     CFMutableDataRef bytes = (CFMutableDataRef)[headers toBytes];
     if (!bytes && [headers count] > 0)

--- a/osx/LightAquaBlue/BBOBEXRequestHandler.m
+++ b/osx/LightAquaBlue/BBOBEXRequestHandler.m
@@ -663,10 +663,10 @@ static BOOL _debug = NO;
 	OBEXMaxPacketLength maxBodySize = maxPacketSize - headersLength;
 
     NSMutableData *data = [NSMutableData dataWithLength:maxBodySize];
-    int len = [mInputStream read:[data mutableBytes]
+    NSInteger len = [mInputStream read:[data mutableBytes]
                        maxLength:maxBodySize];
 
-    if (_debug) NSLog(@"[BBOBEXGetRequestHandler] read %d bytes (maxBodySize = %d)", len, maxBodySize);
+    if (_debug) NSLog(@"[BBOBEXGetRequestHandler] read %ld bytes (maxBodySize = %d)", (long)len, maxBodySize);
 
     // is last packet if there wasn't enough body data to fill up the packet
     if (len >= 0)
@@ -723,7 +723,7 @@ static BOOL _debug = NO;
     if (!mNextResponseHeaders)
         mNextResponseHeaders = [[BBMutableOBEXHeaderSet alloc] init];
     CFMutableDataRef tempHeaderBytes = (CFMutableDataRef)[mNextResponseHeaders toBytes];
-    int currentHeaderLength = 0;
+    CFIndex currentHeaderLength = 0;
     if (tempHeaderBytes) {
         currentHeaderLength = CFDataGetLength(tempHeaderBytes);
         CFRelease(tempHeaderBytes);

--- a/osx/LightAquaBlue/BBServiceAdvertiser.m
+++ b/osx/LightAquaBlue/BBServiceAdvertiser.m
@@ -130,15 +130,12 @@ static NSDictionary *fileTransferProfileDict;
 										withUUID:uuidBlutooth];
 
 	// publish the service
-	IOBluetoothSDPServiceRecordRef serviceRecordRef;
-	IOReturn status = IOBluetoothAddServiceDict((CFDictionaryRef) sdpEntries, &serviceRecordRef);
+	IOBluetoothSDPServiceRecord *serviceRecord;
+    serviceRecord = [IOBluetoothSDPServiceRecord publishedServiceRecordWithDictionary:sdpEntries];
 	[uuid_ autorelease];
 
-	if (status == kIOReturnSuccess) {
-
-		IOBluetoothSDPServiceRecord *serviceRecord =
-			[IOBluetoothSDPServiceRecord withSDPServiceRecordRef:serviceRecordRef];
-
+    IOReturn status = kIOReturnSuccess;
+	if (serviceRecord != nil) {
 		// get service channel ID & service record handle
 		status = [serviceRecord getRFCOMMChannelID:outChannelID];
 		if (status == kIOReturnSuccess) {
@@ -146,7 +143,7 @@ static NSDictionary *fileTransferProfileDict;
 		}
 
 		// cleanup
-		IOBluetoothObjectRelease(serviceRecordRef);
+        [serviceRecord release];
 	}
 
 	return status;
@@ -155,6 +152,8 @@ static NSDictionary *fileTransferProfileDict;
 
 + (IOReturn)removeService:(BluetoothSDPServiceRecordHandle)handle
 {
+    // TODO: We should switch to using [IOBluetoothSDPServiceRecord removeServiceRecord]
+    // but we don't know how to get an IOBluetoothSDPServiceRecord instance from a handle.
 	return IOBluetoothRemoveServiceWithRecordHandle(handle);
 }
 

--- a/osx/LightAquaBlue/BBStreamingInputStream.h
+++ b/osx/LightAquaBlue/BBStreamingInputStream.h
@@ -42,7 +42,7 @@
 
 @protocol BBStreamingInputStreamDelegate
 
-- (NSData *)readDataWithMaxLength:(unsigned int)maxLength;
+- (NSData *)readDataWithMaxLength:(NSUInteger)maxLength;
 
 @end
 

--- a/osx/LightAquaBlue/BBStreamingInputStream.m
+++ b/osx/LightAquaBlue/BBStreamingInputStream.m
@@ -37,18 +37,18 @@
     return self;
 }
 
-- (int)read:(uint8_t *)buffer maxLength:(unsigned int)maxLength
+- (NSInteger)read:(uint8_t *)buffer maxLength:(NSUInteger)maxLength
 {
     NSData *data = [mDelegate readDataWithMaxLength:maxLength];
     if (!data)
         return -1;
 
-    int copyLength = [data length] < maxLength ? [data length] : maxLength;
+    NSUInteger copyLength = [data length] < maxLength ? [data length] : maxLength;
     [data getBytes:buffer length:copyLength];
     return copyLength;
 }
 
-- (BOOL)getBuffer:(uint8_t **)buffer length:(unsigned int *)len
+- (BOOL)getBuffer:(uint8_t **)buffer length:(NSUInteger *)len
 {
     // we cannot access buffer data without calling read:maxLength:
     return NO;

--- a/osx/LightAquaBlue/BBStreamingOutputStream.m
+++ b/osx/LightAquaBlue/BBStreamingOutputStream.m
@@ -34,7 +34,7 @@
     return self;
 }
 
-- (int)write:(const uint8_t *)buffer maxLength:(unsigned int)len
+- (NSInteger)write:(const uint8_t *)buffer maxLength:(NSUInteger)len
 {
     //NSLog(@"[BBStreamingOutputStream] writing data...");
     int buflen = [mDelegate write:[NSData dataWithBytesNoCopy:(void *)buffer

--- a/osx/LightAquaBlue/Info.plist
+++ b/osx/LightAquaBlue/Info.plist
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
-	<key>CFBundleName</key>
-	<string>${PRODUCT_NAME}</string>
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.blammit.LightAquaBlue</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleSignature</key>

--- a/osx/LightAquaBlue/LightAquaBlue.xcodeproj/project.pbxproj
+++ b/osx/LightAquaBlue/LightAquaBlue.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		6692821A0E297230008CB8B0 /* BridgeSupport in Resources */ = {isa = PBXBuildFile; fileRef = 669282170E297230008CB8B0 /* BridgeSupport */; };
+		2A841F731FBC0935008778A4 /* BridgeSupport in Resources */ = {isa = PBXBuildFile; fileRef = 2A841F721FBC0935008778A4 /* BridgeSupport */; };
 		8100016A0D09536000FA9985 /* BBStreamingOutputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 810001680D09536000FA9985 /* BBStreamingOutputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8100016B0D09536000FA9985 /* BBStreamingOutputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 810001690D09536000FA9985 /* BBStreamingOutputStream.m */; };
 		8100FE030D056D0100FA9985 /* BBBluetoothOBEXClient.h in Headers */ = {isa = PBXBuildFile; fileRef = 8100FDEB0D056D0000FA9985 /* BBBluetoothOBEXClient.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -46,8 +46,8 @@
 		0867D6A5FE840307C02AAC07 /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		089C1667FE841158C02AAC07 /* English */ = {isa = PBXFileReference; fileEncoding = 10; lastKnownFileType = text.plist.strings; name = English; path = English.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		1058C7B1FEA5585E11CA2CBB /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
+		2A841F721FBC0935008778A4 /* BridgeSupport */ = {isa = PBXFileReference; lastKnownFileType = folder; path = BridgeSupport; sourceTree = "<group>"; };
 		32DBCF5E0370ADEE00C91783 /* LightAquaBlue_Prefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LightAquaBlue_Prefix.pch; sourceTree = "<group>"; };
-		669282170E297230008CB8B0 /* BridgeSupport */ = {isa = PBXFileReference; lastKnownFileType = folder; path = BridgeSupport; sourceTree = "<group>"; };
 		810001680D09536000FA9985 /* BBStreamingOutputStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BBStreamingOutputStream.h; sourceTree = "<group>"; };
 		810001690D09536000FA9985 /* BBStreamingOutputStream.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BBStreamingOutputStream.m; sourceTree = "<group>"; };
 		8100FDEB0D056D0000FA9985 /* BBBluetoothOBEXClient.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = BBBluetoothOBEXClient.h; sourceTree = "<group>"; };
@@ -128,7 +128,7 @@
 		089C1665FE841158C02AAC07 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				669282170E297230008CB8B0 /* BridgeSupport */,
+				2A841F721FBC0935008778A4 /* BridgeSupport */,
 				8100FE000D056D0100FA9985 /* OBEXFileTransferDictionary.plist */,
 				8100FE010D056D0100FA9985 /* OBEXObjectPushDictionary.plist */,
 				8100FE020D056D0100FA9985 /* SerialPortDictionary.plist */,
@@ -245,7 +245,7 @@
 		0867D690FE84028FC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0430;
+				LastUpgradeCheck = 0910;
 			};
 			buildConfigurationList = 1DEB91B108733DA50010E9CD /* Build configuration list for PBXProject "LightAquaBlue" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -273,7 +273,7 @@
 				8100FE180D056D0100FA9985 /* OBEXFileTransferDictionary.plist in Resources */,
 				8100FE190D056D0100FA9985 /* OBEXObjectPushDictionary.plist in Resources */,
 				8100FE1A0D056D0100FA9985 /* SerialPortDictionary.plist in Resources */,
-				6692821A0E297230008CB8B0 /* BridgeSupport in Resources */,
+				2A841F731FBC0935008778A4 /* BridgeSupport in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -327,6 +327,7 @@
 				GCC_PREFIX_HEADER = LightAquaBlue_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.blammit.LightAquaBlue;
 				PRODUCT_NAME = LightAquaBlue;
 				WRAPPER_EXTENSION = framework;
 				ZERO_LINK = YES;
@@ -336,10 +337,6 @@
 		1DEB91AF08733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = (
-					ppc,
-					i386,
-				);
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				FRAMEWORK_VERSION = A;
@@ -349,6 +346,7 @@
 				GCC_PREFIX_HEADER = LightAquaBlue_Prefix.pch;
 				INFOPLIST_FILE = Info.plist;
 				INSTALL_PATH = "$(HOME)/Library/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.blammit.LightAquaBlue;
 				PRODUCT_NAME = LightAquaBlue;
 				WRAPPER_EXTENSION = framework;
 			};
@@ -357,18 +355,60 @@
 		1DEB91B208733DA50010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = "";
+				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
 		};
 		1DEB91B308733DA50010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(NATIVE_ARCH_ACTUAL)";
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 			};
 			name = Release;

--- a/osx/LightAquaBlue/LightAquaBlue.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/osx/LightAquaBlue/LightAquaBlue.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/osx/_LightAquaBlue.py
+++ b/osx/_LightAquaBlue.py
@@ -25,36 +25,16 @@ classes through PyObjC.
 
 import objc
 import os.path
+from pkg_resources import resource_filename
 
-_FRAMEWORK_PATH = '/Library/Frameworks/LightAquaBlue.framework'
+_FRAMEWORK_PATH = resource_filename('lightblue', 'LightAquaBlue.framework')
 if not os.path.isdir(_FRAMEWORK_PATH):
-    raise ImportError("Cannot load LightAquaBlue framework, not found at" + \
+    raise ImportError("Cannot load LightAquaBlue framework, not found at " + \
         _FRAMEWORK_PATH)
 
-try:
-    # mac os 10.5 loads frameworks using bridgesupport metadata
-    __bundle__ = objc.initFrameworkWrapper("LightAquaBlue",
-            frameworkIdentifier="com.blammit.LightAquaBlue",
-            frameworkPath=objc.pathForFramework(_FRAMEWORK_PATH),
-            globals=globals())
-
-except AttributeError:
-    # earlier versions use loadBundle() and setSignatureForSelector()
-
-    objc.loadBundle("LightAquaBlue", globals(),
-       bundle_path=objc.pathForFramework(_FRAMEWORK_PATH))
-
-    # return int, take (object, object, object, output unsigned char, output int)
-    # i.e. in python: return (int, char, int), take (object, object, object)
-    objc.setSignatureForSelector("BBServiceAdvertiser",
-        "addRFCOMMServiceDictionary:withName:UUID:channelID:serviceRecordHandle:",
-        "i@0:@@@o^Co^I")
-
-    # set to take (6-char array, unsigned char, object)
-    # this seems to work even though the selector doesn't take a char aray,
-    # it takes a struct 'BluetoothDeviceAddress' which contains a char array.
-    objc.setSignatureForSelector("BBBluetoothOBEXClient",
-            "initWithRemoteDeviceAddress:channelID:delegate:",
-            '@@:r^[6C]C@')
+__bundle__ = objc.initFrameworkWrapper("LightAquaBlue",
+        frameworkIdentifier="com.blammit.LightAquaBlue",
+        frameworkPath=objc.pathForFramework(_FRAMEWORK_PATH),
+        globals=globals())
 
 del objc

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,13 @@ import sys
 import platform
 import os
 
-packs = ['bluetooth']
-pack_dir = dict()
-mods = list()
-install_req = list()
+packages = ['bluetooth']
+package_dir = dict()
+ext_modules = list()
+install_requires = list()
+package_data = dict()
+eager_resources = list()
+zip_safe = True
 
 
 def find_MS_SDK():
@@ -49,7 +52,7 @@ if sys.platform == 'win32':
     lib_path = os.path.join(PSDK_PATH, 'Lib')
     if '64' in platform.architecture()[0]:
         lib_path = os.path.join(lib_path, 'x64')
-    mods.append(Extension('bluetooth._msbt',
+    ext_modules.append(Extension('bluetooth._msbt',
                           include_dirs=["%s\\Include" % PSDK_PATH, ".\\port3"],
                           library_dirs=[lib_path],
                           libraries=["WS2_32", "Irprops"],
@@ -58,7 +61,7 @@ if sys.platform == 'win32':
     # widcomm
     WC_BASE = os.path.join(os.getenv('ProgramFiles'), r"Widcomm\BTW DK\SDK")
     if os.path.exists(WC_BASE):
-        mods.append(Extension('bluetooth._widcomm',
+        ext_modules.append(Extension('bluetooth._widcomm',
                 include_dirs=["%s\\Inc" % WC_BASE, ".\\port3"],
                 define_macros=[('_BTWLIB', None)],
                 library_dirs=["%s\\Release" % WC_BASE, "%s\\Lib" % PSDK_PATH],
@@ -79,43 +82,38 @@ elif sys.platform.startswith('linux'):
                         libraries = ['bluetooth'],
                         #extra_compile_args=['-O0'],
                         sources = ['bluez/btmodule.c', 'bluez/btsdp.c'])
-    mods = [ mod1 ]
+    ext_modules.append(mod1)
 
 elif sys.platform.startswith("darwin"):
-    # On Mac, install LightAquaBlue framework
-    # if you want to install the framework somewhere other than /Library/Frameworks
-    # make sure the path is also changed in LightAquaBlue.py (in src/mac)
-    packs.append('lightblue')
-    pack_dir = { 'lightblue': 'osx' }
-    if "install" in sys.argv:
-        install_req = ['pyobjc-core>=3.1', 'pyobjc-framework-Cocoa>=3.1']
-        # Change to LightAquaBlue framework dir.
-        os.chdir("osx/LightAquaBlue")
-
-        #
-        # NOTE: our solution is based on these posts:
-        #  - http://stackoverflow.com/questions/22279913/how-to-install-either-pybluez-or-lightblue-on-osx-10-9-mavericks
-        #  - https://github.com/0-1-0/lightblue-0.4/issues/7
-        # We need to verify that the arch(itecture) param is specified accurately 
-        # otherwise the compilation will fail.
-        #
-        arch = None
-        if "NATIVE_ARCH_ACTUAL" in os.environ:
-            arch = "$(NATIVE_ARCH_ACTUAL)"
-        elif "64bit" in platform.architecture():
-            arch = "x86_64"
-        elif "32bit" in platform.architecture():
-            arch = "i386"
-        else:
-            raise Exception("Unrecognized architecture")
-
-        build_str = "xcodebuild install -arch '%s' -target LightAquaBlue -configuration Release DSTROOT=/ INSTALL_PATH=/Library/Frameworks DEPLOYMENT_LOCATION=YES" % (arch)
-        os.system(build_str)
-
-        # Change back to top-level (need this otherwise setup.py script gets confused on install?).
-        os.chdir("../..")
-
-        mods = []
+    packages.append('lightblue')
+    package_dir['lightblue'] = 'osx'
+    install_requires += ['pyobjc-core>=3.1', 'pyobjc-framework-Cocoa>=3.1']
+    zip_safe = False
+    
+    # FIXME: This is inelegant, how can we cover the cases?
+    if 'install' in sys.argv or 'bdist' in sys.argv or 'bdist_egg' in sys.argv:
+        # Build the framework into osx/
+        import subprocess
+        subprocess.check_call([
+            'xcodebuild', 'install',
+            '-project', 'osx/LightAquaBlue/LightAquaBlue.xcodeproj',
+            '-scheme', 'LightAquaBlue',
+            'DSTROOT=' + os.path.join(os.getcwd(), 'osx'),
+            'INSTALL_PATH=/',
+            'DEPLOYMENT_LOCATION=YES',
+        ])
+        
+        # We can't seem to list a directory as package_data, so we will
+        # recursively add all all files we find
+        package_data['lightblue'] = []
+        for path, _, files in os.walk('osx/LightAquaBlue.framework'):
+            for f in files:
+                include = os.path.join(path, f)[4:]  # trim off osx/
+                package_data['lightblue'].append(include)
+    
+        # This should allow us to use the framework from an egg [untested]
+        eager_resources.append('osx/LightAquaBlue.framework')
+        
 else:
     raise Exception("This platform (%s) is currently not supported by pybluez."
                     % sys.platform)
@@ -127,8 +125,8 @@ setup(name='PyBluez',
       author="Albert Huang",
       author_email="ashuang@alum.mit.edu",
       url="http://karulis.github.io/pybluez/",
-      ext_modules=mods,
-      packages=packs,
+      ext_modules=ext_modules,
+      packages=packages,
 # for the python cheese shop
       classifiers=['Development Status :: 4 - Beta',
                    'License :: OSI Approved :: GNU General Public License (GPL)',
@@ -139,10 +137,13 @@ setup(name='PyBluez',
       download_url='https://github.com/karulis/pybluez',
       long_description='Bluetooth Python extension module to allow Python "\
                 "developers to use system Bluetooth resources. PyBluez works "\
-                "with GNU/Linux and Windows XP.',
+                "with GNU/Linux, macOS, and Windows XP.',
       maintainer='Piotr Karulis',
       license='GPL',
       extras_require={'ble': ['gattlib==0.20150805']},
-      package_dir=pack_dir,
+      package_dir=package_dir,
       use_2to3=True,
-      install_requires=install_req)
+      install_requires=install_requires,
+      package_data=package_data,
+      eager_resources=eager_resources,
+      zip_safe=zip_safe)


### PR DESCRIPTION
I was having trouble using PyBluez on macOS. This pull request makes progress towards better support for macOS.

- Correctly declares package dependencies, which fixes installing with pip (which was not receiving the dependencies when executing `setup.py egg_info`)
- Builds LightAquaBlue.framework inside the lightblue package, rather than installing it to /Library/Frameworks
- Removes the hacky architecture detection when building LightAquaBlue and lets Xcode decide
- Modernizes the LightAquaBlue.xcodeproj
- Addresses a number of warnings inside LightAquaBlue related to integer type widths
- Replaces a deprecated API call to `IOBluetoothAddServiceDict`
- Removes a very old way of loading the LightAquaBlue.framework for systems older than 10.5
- Adds some macOS temporary files to the .gitignore exclusion list