### PR TITLE
Support LIAC as well as GIAC

### DIFF
--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -21,7 +21,7 @@ del _constants
 # ============== SDP service registration and unregistration ============
 
 def discover_devices (duration=8, flush_cache=True, lookup_names=False,
-                      lookup_class=False, device_id=-1, iac=_bt.IAC_GIAC):
+                      lookup_class=False, device_id=-1, iac=IAC_GIAC):
     if device_id == -1:
         device_id = _bt.hci_get_route()
 

--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -21,14 +21,15 @@ del _constants
 # ============== SDP service registration and unregistration ============
 
 def discover_devices (duration=8, flush_cache=True, lookup_names=False,
-                      lookup_class=False, device_id=-1):
+                      lookup_class=False, device_id=-1, iac=_bt.IAC_GIAC):
     if device_id == -1:
         device_id = _bt.hci_get_route()
 
     sock = _gethcisock (device_id)
     try:
         results = _bt.hci_inquiry (sock, duration=duration, flush_cache=True,
-                                   lookup_class=lookup_class, device_id=device_id)
+                                   lookup_class=lookup_class, device_id=device_id,
+                                   iac=iac)
     except _bt.error:
         sock.close ()
         raise BluetoothError ("error communicating with local "

--- a/bluetooth/btcommon.py
+++ b/bluetooth/btcommon.py
@@ -172,6 +172,10 @@ CMTP_UUID      = "001b"
 UDI_UUID       = "001d"
 L2CAP_UUID     = "0100"
 
+# Inquiry Access Codes
+IAC_GIAC = 0x9e8b33
+IAC_LIAC = 0x9e8b00
+
 class BluetoothError (IOError):
     pass
 

--- a/bluez/btmodule.c
+++ b/bluez/btmodule.c
@@ -2097,6 +2097,7 @@ bt_hci_inquiry(PyObject *self, PyObject *args, PyObject *kwds)
     int flush = 1;
     int flags = 0;
     int lookup_class = 0;
+    int iac = 0x9e8b33;
     char ba_name[19];
     inquiry_info *info = NULL;
     PySocketSockObject *socko = NULL;
@@ -2104,10 +2105,10 @@ bt_hci_inquiry(PyObject *self, PyObject *args, PyObject *kwds)
     char buf[sizeof(*ir) + sizeof(inquiry_info) * 250];
 
     PyObject *rtn_list = (PyObject *)NULL;
-    static char *keywords[] = {"sock", "duration", "flush_cache", "lookup_class", "device_id", 0};
+    static char *keywords[] = {"sock", "duration", "flush_cache", "lookup_class", "device_id", "iac", 0};
 
-    if( !PyArg_ParseTupleAndKeywords(args, kwds, "O|iiii", keywords,
-                &socko, &length, &flush, &lookup_class, &dev_id) )
+    if( !PyArg_ParseTupleAndKeywords(args, kwds, "O|iiiii", keywords,
+                &socko, &length, &flush, &lookup_class, &dev_id, &iac) )
     {
         return 0;
     }
@@ -2121,9 +2122,9 @@ bt_hci_inquiry(PyObject *self, PyObject *args, PyObject *kwds)
     ir->length  = length;
     ir->flags   = flags;
 
-    ir->lap[0] = 0x33;
-    ir->lap[1] = 0x8b;
-    ir->lap[2] = 0x9e;
+    ir->lap[0] = iac & 0xff;
+    ir->lap[1] = (iac >> 8) & 0xff;
+    ir->lap[2] = (iac >> 16) & 0xff;
 
     Py_BEGIN_ALLOW_THREADS
     err = ioctl(socko->sock_fd, HCIINQUIRY, (unsigned long) buf);


### PR DESCRIPTION
Some devices using LIAC for the inquiry process (e.g. a third-party Wii Remote) couldn't be discovered otherwise. See https://www.bluetooth.com/specifications/assigned-numbers/baseband