### PR TITLE
Build in travis-ci against latest bluez-5.49 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,22 @@ python:
   - "2.7"
   - "3.6"
 
+env:
+  global:
+    - BLUEZ_SRC_DIR="./contrib/bluez"
+    - LOCAL_INCLUDE_DIR="./include"
+
 os:
   - linux
 
 before_install:
+  
+  - git clone https://git.kernel.org/pub/scm/bluetooth/bluez.git -n $BLUEZ_SRC_DIR && cd $BLUEZ_SRC_DIR && git checkout $(git describe --tags $(git rev-list --tags='[0-9]*.[0-9]*' -n 1)) && cd -
+  - mkdir -p $LOCAL_INCLUDE_DIR/bluetooth && cp $BLUEZ_SRC_DIR/lib/*.h $LOCAL_INCLUDE_DIR/bluetooth
   - pip install -r requirements.txt
 
 install:
+  - CFLAGS="-I$LOCAL_INCLUDE_DIR" python setup.py build
   - python setup.py install
 
 script:


### PR DESCRIPTION
This should resolve the issue where pybluez could not be built because it relies on new features that are not included in the old version of Bluez included in the version of Ubuntu Travis-CI uses.

Resolves #193 