### PR TITLE
Add support for getpeername on Windows

### DIFF
--- a/bluetooth/msbt.py
+++ b/bluetooth/msbt.py
@@ -95,6 +95,9 @@ class BluetoothSocket:
     def getsockname (self):
         return bt.getsockname (self._sockfd)
 
+    def getpeername (self):
+        return bt.getpeername (self._sockfd)
+
     def setblocking (self, blocking):
         bt.setblocking (self._sockfd, blocking)
         self._blocking = blocking

--- a/bluetooth/msbt.py
+++ b/bluetooth/msbt.py
@@ -98,6 +98,8 @@ class BluetoothSocket:
     def getpeername (self):
         return bt.getpeername (self._sockfd)
 
+    getpeername.__doc__ = bt.getpeername.__doc__
+
     def setblocking (self, blocking):
         bt.setblocking (self._sockfd, blocking)
         self._blocking = blocking

--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -321,6 +321,29 @@ msbt_close(PyObject *self, PyObject *args)
 PyDoc_STRVAR(msbt_close_doc, "TODO");
 
 static PyObject *
+msbt_getpeername(PyObject *self, PyObject *args)
+{
+    int sockfd = -1;
+    SOCKADDR_BTH sa = { 0 };
+    int sa_len = sizeof(sa);
+    char buf[100] = { 0 };
+    int buf_len = sizeof(buf);
+    int status;
+    if(!PyArg_ParseTuple( args, "i", &sockfd )) return 0;
+
+    sa.addressFamily = AF_BTH;
+    Py_BEGIN_ALLOW_THREADS;
+    status = getpeername( sockfd, (LPSOCKADDR)&sa, &sa_len );
+    Py_END_ALLOW_THREADS;
+
+    _CHECK_OR_RAISE_WSA( NO_ERROR == status );
+
+    ba2str( sa.btAddr, buf, buf_len );
+    return Py_BuildValue( "si", buf, sa.port );
+};
+PyDoc_STRVAR(msbt_getpeername_doc, "TODO");
+
+static PyObject *
 msbt_getsockname(PyObject *self, PyObject *args)
 {
     int sockfd = -1;
@@ -971,6 +994,8 @@ static PyMethodDef msbt_methods[] = {
     { "close", (PyCFunction)msbt_close, METH_VARARGS, msbt_close_doc },
     { "getsockname", (PyCFunction)msbt_getsockname, METH_VARARGS, 
         msbt_getsockname_doc },
+    { "getpeername", (PyCFunction)msbt_getpeername, METH_VARARGS,
+        msbt_getpeername_doc },
     { "dup", (PyCFunction)msbt_dup, METH_VARARGS, msbt_dup_doc },
     { "discover_devices", (PyCFunction)msbt_discover_devices,
             METH_VARARGS | METH_KEYWORDS, msbt_discover_devices_doc },

--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -341,7 +341,16 @@ msbt_getpeername(PyObject *self, PyObject *args)
     ba2str( sa.btAddr, buf, buf_len );
     return Py_BuildValue( "si", buf, sa.port );
 };
-PyDoc_STRVAR(msbt_getpeername_doc, "TODO");
+PyDoc_STRVAR(msbt_getpeername_doc,
+"getpeername() -> address info\n\
+\n\
+Return the address of the peer to which a socket is connected.\n\
+This function works with any address family and it simply returns the \n\
+address to which the socket is connected. The getpeername function can be \n\
+used only on a connected socket.\n\
+For datagram sockets, only the address of a peer specified in a previous \n\
+connect call will be returned. Any address specified by a previous sendto \n\
+call will not be returned by getpeername.");
 
 static PyObject *
 msbt_getsockname(PyObject *self, PyObject *args)

--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -326,7 +326,7 @@ msbt_getpeername(PyObject *self, PyObject *args)
     int sockfd = -1;
     SOCKADDR_BTH sa = { 0 };
     int sa_len = sizeof(sa);
-    char buf[100] = { 0 };
+    char buf[18] = { 0 };
     int buf_len = sizeof(buf);
     int status;
     if(!PyArg_ParseTuple( args, "i", &sockfd )) return 0;
@@ -358,7 +358,7 @@ msbt_getsockname(PyObject *self, PyObject *args)
     int sockfd = -1;
     SOCKADDR_BTH sa = { 0 };
     int sa_len = sizeof(sa);
-    char buf[100] = { 0 };
+    char buf[18] = { 0 };
     int buf_len = sizeof(buf);
     int status;
     if(!PyArg_ParseTuple( args, "i", &sockfd )) return 0;


### PR DESCRIPTION
The implementation of this method closely follows getsockname. Adding
the method enables use-cases such as https://github.com/ScR4tCh/timebox

This change was created together with @Smarker.