### PR TITLE
Sourcell xu patch bluez.py

### DIFF
--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -2,7 +2,7 @@ import sys
 import struct
 from errno import (EADDRINUSE, EBUSY, EINVAL)
 
-if sys.version < '3':
+if sys.version_info.major < 3:
     from .btcommon import *
     import _bluetooth as _bt
     get_byte = ord

--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -75,7 +75,7 @@ def read_local_bdaddr():
         status,raw_bdaddr = struct.unpack("xxxxxxB6s", pkt)
         assert status == 0
 
-        t = [ "%X" % get_byte(b) for b in raw_bdaddr ]
+        t = [ "%02X" % get_byte(b) for b in raw_bdaddr ]
         t.reverse()
         bdaddr = ":".join(t)
 


### PR DESCRIPTION
1. Modify the code used to determine python version

   If other modules change `sys.version` then import bluez.py, the code used to determine python version will be failure, therefore we should use `sys.version_info.major` to get readonly python major version instead.

2. Update bluez.py `read_local_bdaddr()`

   When we use the BD_ADDR as a string, each byte of the BD_ADDR should be converted into two hexadecimal digits, not one hexadecimal digit. Otherwise we might fail to call `hci_devid()` using the return value, for example `['0:XX:XX:XX:XX:XX']`, of the `read_local_bdaddr()`.