### PR TITLE
Fix "AttributeError: 'error' object has no attribute 'errno'"

### DIFF
--- a/bluetooth/bluez.py
+++ b/bluetooth/bluez.py
@@ -197,7 +197,7 @@ class BluetoothSocket:
                 return self._sock.bind ((addr, port))
             except _bt.error as e:
                 err = BluetoothError (*e.args)
-                if e.errno != EADDRINUSE:
+                if err.errno != EADDRINUSE:
                     break
         raise err
 


### PR DESCRIPTION
### Description

When binding to a port, the behavior is to iterate over possible channels until one that isn't occupied is found. This is done by catching the exception thrown in this case.

Right now, if channel 1 is occupied, an `AttributeError` is thrown. This is because instead of checking the `errno` of the `BluetoothError` object that was just constructed, the code instead checks this (non-existent) property on a `_bt.error`.

### How to replicate
`python examples/simple/rfcomm-server.py`

Then, in another terminal, run the same command again.