### PR TITLE
Use feature detection instead of version detection

### DIFF
--- a/examples/simple/l2capclient.py
+++ b/examples/simple/l2capclient.py
@@ -5,8 +5,10 @@
 import sys
 import bluetooth
 
-if sys.version < '3':
+try:
     input = raw_input
+except NameError:
+    pass  # Python 3
 
 sock=bluetooth.BluetoothSocket(bluetooth.L2CAP)
 


### PR DESCRIPTION
Follow the Python porting best practice: [Use feature detection instead of version detection](https://docs.python.org/3/howto/pyporting.html#use-feature-detection-instead-of-version-detection).