### PR TITLE
Fix deprecated API warnings, close #96

### DIFF
--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -1,3 +1,7 @@
+#ifndef UNICODE
+#define UNICODE
+#endif
+
 #include <winsock2.h>
 #include <ws2bth.h>
 #include <BluetoothAPIs.h>
@@ -150,7 +154,7 @@ PyDoc_STRVAR(msbt_socket_doc, "TODO");
 static PyObject *
 msbt_bind(PyObject *self, PyObject *args)
 {
-    char *addrstr = NULL;
+    wchar_t *addrstr = NULL;
     int addrstrlen = -1;
     int sockfd = -1;
     int port = -1;
@@ -230,7 +234,7 @@ static PyObject *
 msbt_connect(PyObject *self, PyObject *args)
 {
     int sockfd = -1;
-    char *addrstr = NULL;
+    wchar_t *addrstr = NULL;
     int port = -1;
     SOCKADDR_BTH sa = { 0 };
     int sa_len = sizeof(sa);
@@ -543,7 +547,7 @@ msbt_lookup_name(PyObject *self, PyObject *args)
     BLUETOOTH_FIND_RADIO_PARAMS p = { sizeof(p) };
     HBLUETOOTH_RADIO_FIND fhandle = NULL;
     BLUETOOTH_DEVICE_INFO dinfo = { 0 };
-    char *addrstr = NULL;
+    wchar_t *addrstr = NULL;
     SOCKADDR_BTH sa = { 0 };
     int sa_len = sizeof(sa);
     DWORD status;
@@ -599,7 +603,7 @@ msbt_find_service(PyObject *self, PyObject *args)
 	qs->dwSize = sizeof(WSAQUERYSET);
 	qs->dwNameSpace = NS_BTH;
     qs->dwNumberOfCsAddrs = 0;
-    qs->lpszContext = (LPSTR) localAddressBuf;
+    qs->lpszContext = (LPWSTR) localAddressBuf;
 
     if( 0 == strcmp( addrstr, "localhost" ) ) {
         // find the Bluetooth address of the first local adapter. 
@@ -692,10 +696,10 @@ msbt_find_service(PyObject *self, PyObject *args)
             dict_set_strings( record, "host", localAddressBuf );
             
             // set service name
-            dict_set_strings( record, "name", qs->lpszServiceInstanceName );
+            dict_set_strings( record, "name", (const char*) qs->lpszServiceInstanceName );
 
             // set description
-            dict_set_strings( record, "description", qs->lpszComment );
+            dict_set_strings( record, "description", (const char*) qs->lpszComment );
 
             // set protocol and port
             csinfo = qs->lpcsaBuffer;
@@ -815,8 +819,8 @@ msbt_set_service(PyObject *self, PyObject *args)
 
 	SOCKADDR_BTH sa = { 0 };
 	int sa_len = sizeof(sa);
-    char *service_name = NULL;
-    char *service_desc = NULL;
+    wchar_t *service_name = NULL;
+    wchar_t *service_desc = NULL;
     char *service_class_id_str = NULL;
 	CSADDR_INFO sockInfo = { 0 };
     GUID uuid = { 0 };


### PR DESCRIPTION
This patch resolves #96.
I tested this on Windows 10 using python 3.6 32 bit and python 3.7 64 bit by installing from source and running the example inquiry.py. I don't have access to earlier versions of Windows so can't test backwards compatibility.
 
I've attached the egg file for the community to test on earlier windows versions. 
Download [PyBluez-0.22-py3.6-win32.zip](https://github.com/pybluez/pybluez/files/3508727/PyBluez-0.22-py3.6-win32.zip) and rename to PyBluez-0.22-py3.6-win32.egg

 