### PR TITLE
Example fixes for printing and type issues in Python3

### DIFF
--- a/examples/simple/rfcomm-client.py
+++ b/examples/simple/rfcomm-client.py
@@ -39,13 +39,13 @@ if len(service_matches) == 0:
 first_match = service_matches[0]
 port = first_match["port"]
 name = first_match["name"]
-host = first_match["host"]
+host = first_match["host"].decode()
 
 print("Connecting to \"{}\" on {}".format(name, host))
 
 # Create the client socket
 sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-sock.connect((host.decode(), port))
+sock.connect((host, port))
 
 print("Connected. Type something...")
 while True:

--- a/examples/simple/rfcomm-client.py
+++ b/examples/simple/rfcomm-client.py
@@ -45,13 +45,13 @@ print("Connecting to \"{}\" on {}".format(name, host))
 
 # Create the client socket
 sock = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-sock.connect((host, port))
+sock.connect((host.decode(), port))
 
 print("Connected. Type something...")
 while True:
     data = input()
     if not data:
         break
-    sock.send(data)
+    sock.send(str.encode(data))
 
 sock.close()

--- a/examples/simple/rfcomm-server.py
+++ b/examples/simple/rfcomm-server.py
@@ -24,17 +24,17 @@ bluetooth.advertise_service(server_sock, "SampleServer", service_id=uuid,
                             # protocols=[bluetooth.OBEX_UUID]
                             )
 
-print("Waiting for connection on RFCOMM channel", port)
+print("Waiting for connection on RFCOMM channel {}".format(port))
 
 client_sock, client_info = server_sock.accept()
-print("Accepted connection from", client_info)
+print("Accepted connection from {}".format(client_info))
 
 try:
     while True:
         data = client_sock.recv(1024)
         if not data:
             break
-        print("Received", data)
+        print("Received {}".format(data.decode())
 except IOError:
     pass
 

--- a/examples/simple/rfcomm-server.py
+++ b/examples/simple/rfcomm-server.py
@@ -34,7 +34,7 @@ try:
         data = client_sock.recv(1024)
         if not data:
             break
-        print("Received {}".format(data.decode())
+        print("Received {}".format(data.decode()))
 except IOError:
     pass
 


### PR DESCRIPTION
- Fixes string conversions and unifies conventions of using `print("{}".format(foo))` style printing between both example scripts 
- Fixes exception caused by using string type instead of byte type (see #216)

Tested with ubuntu 18.04 and macOS Catalina, with macOS installed via source and via pip on Linux. Tested with python3. I did not test python2, as there are other unrelated compatibility issues with python2. 