### PR TITLE
Add missing family, type and proto properties to msbt socket backend

### DIFF
--- a/bluetooth/msbt.py
+++ b/bluetooth/msbt.py
@@ -64,6 +64,18 @@ class BluetoothSocket:
         self._blocking = True
         self._timeout = False
 
+    @property
+    def family (self):
+        return bt.AF_BTH
+
+    @property
+    def type (self):
+        return bt.SOCK_STREAM
+
+    @property
+    def proto (self):
+        return bt.BTHPROTO_RFCOMM
+
     def bind (self, addrport):
         if self._proto == RFCOMM:
             addr, port = addrport

--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -1055,6 +1055,7 @@ PyInit__msbt(void)
     m = PyModule_Create(&moduledef);
 #endif
 
+    ADD_INT_CONSTANT(m, AF_BTH);
     ADD_INT_CONSTANT(m, SOCK_STREAM);
     ADD_INT_CONSTANT(m, BTHPROTO_RFCOMM);
     ADD_INT_CONSTANT(m, BT_PORT_ANY);


### PR DESCRIPTION
This is the Windows (msbt) counterpart of #227.