### PR TITLE
PyUnicode_FromStringAndSize changed to PyBytes_FromStringAndSize to prevent segfault when calling _PyBytes_Resize 

### DIFF
--- a/bluez/btmodule.c
+++ b/bluez/btmodule.c
@@ -779,7 +779,7 @@ sock_getsockopt(PySocketSockObject *s, PyObject *args)
         PyErr_SetString(bluetooth_error, "getsockopt buflen out of range");
         return NULL;
     } else {
-        PyObject *buf = PyUnicode_FromStringAndSize((char *)NULL, buflen);
+        PyObject *buf = PyBytes_FromStringAndSize((char *)NULL, buflen);
         if (buf == NULL)
             return NULL;
         res = getsockopt(s->sock_fd, level, optname,


### PR DESCRIPTION
This fixes the issue reported in Issue #302.