### PR TITLE
Properly handle the now wchar error messages

### DIFF
--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -31,8 +31,12 @@ static void Err_SetFromWSALastError(PyObject *exc)
 	LPVOID lpMsgBuf;
 	FormatMessage( FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
 		NULL, WSAGetLastError(), 0, (LPTSTR) &lpMsgBuf, 0, NULL );
-    PyErr_SetString( exc, lpMsgBuf );
+	PyObject *msg = PyUnicode_FromWideChar((LPTSTR) lpMsgBuf, -1);
 	LocalFree(lpMsgBuf);
+	if (msg != NULL) {
+		PyErr_SetObject( exc, msg );
+		Py_DECREF(msg);
+	}
 }
 
 


### PR DESCRIPTION
The message was truncated to something like `OSError: A` due to encoding issue. Now instead of using `PyErr_SetString` (which accepts a UTF-8 string) on the wide string directly, we wrap the wide string in a `PyUnicode` object and then set it with `PyErr_SetObject`.