### PR TITLE
make pybluez compile on newer osx versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        os: [macos-latest, ubuntu-latest, windows-latest]
+        os: [macos-10.13, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,13 +28,12 @@ jobs:
         sudo apt install bluez libbluetooth-dev
     - name: setup xcode version
       if: startsWith(matrix.os, 'macos')
-    - uses: maxim-lobanov/setup-xcode@v1
+      uses: maxim-lobanov/setup-xcode@v1
       with:
         xcode-version: '11'
     - name: show sdks
       if: startsWith(matrix.os, 'macos')
       run: |
-        xcode-select 
         xcodebuild -showsdks
     - name: Lint
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       if: startsWith(matrix.os, 'macos')
       uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '11'
+        xcode-version: '10'
     - name: show sdks
       if: startsWith(matrix.os, 'macos')
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        os: [macos-10.13, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -26,9 +26,16 @@ jobs:
       run: |
         sudo apt update
         sudo apt install bluez libbluetooth-dev
+    - name: setup xcode version
+      if: startsWith(matrix.os, 'macos')
+    - uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: '11'
     - name: show sdks
       if: startsWith(matrix.os, 'macos')
-      run: xcodebuild -showsdks
+      run: |
+        xcode-select 
+        xcodebuild -showsdks
     - name: Lint
       run: |
         pip install flake8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        os: [macOS-latest, ubuntu-latest, windows-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 
@@ -26,6 +26,9 @@ jobs:
       run: |
         sudo apt update
         sudo apt install bluez libbluetooth-dev
+    - name: show sdks
+      if: startsWith(matrix.os, 'macos')
+      run: xcodebuild -showsdks
     - name: Lint
       run: |
         pip install flake8

--- a/macos/LightAquaBlue/BBServiceAdvertiser.h
+++ b/macos/LightAquaBlue/BBServiceAdvertiser.h
@@ -67,12 +67,12 @@
 							  withName:(NSString *)serviceName
 								  UUID:(NSString *)uuid
 							 channelID:(BluetoothRFCOMMChannelID *)outChannelID
-				   serviceRecordHandle:(BluetoothSDPServiceRecordHandle *)outServiceRecordHandle;
+				   		 serviceRecord:(IOBluetoothSDPServiceRecord *)serviceRecord;
 
 
 /*
  * Stop advertising a service.
  */
-+ (IOReturn)removeService:(BluetoothSDPServiceRecordHandle)handle;
++ (IOReturn)removeService:(IOBluetoothSDPServiceRecord *)serviceRecord;
 
 @end

--- a/macos/LightAquaBlue/BBServiceAdvertiser.m
+++ b/macos/LightAquaBlue/BBServiceAdvertiser.m
@@ -113,7 +113,7 @@ static NSDictionary *fileTransferProfileDict;
 							  withName:(NSString *)serviceName
 								  UUID:(NSString *)uuid
 							 channelID:(BluetoothRFCOMMChannelID *)outChannelID
-				   serviceRecordHandle:(BluetoothSDPServiceRecordHandle *)outServiceRecordHandle
+				   		 serviceRecord:(IOBluetoothSDPServiceRecord *)serviceRecord
 {
 	if (dict == nil)
 		return kIOReturnError;
@@ -130,7 +130,7 @@ static NSDictionary *fileTransferProfileDict;
 										withUUID:uuidBlutooth];
 
 	// publish the service
-	IOBluetoothSDPServiceRecord *serviceRecord;
+	//IOBluetoothSDPServiceRecord *serviceRecord;
     serviceRecord = [IOBluetoothSDPServiceRecord publishedServiceRecordWithDictionary:sdpEntries];
 	[uuid_ autorelease];
 
@@ -138,9 +138,6 @@ static NSDictionary *fileTransferProfileDict;
 	if (serviceRecord != nil) {
 		// get service channel ID & service record handle
 		status = [serviceRecord getRFCOMMChannelID:outChannelID];
-		if (status == kIOReturnSuccess) {
-			status = [serviceRecord getServiceRecordHandle:outServiceRecordHandle];
-		}
 
 		// cleanup
         [serviceRecord release];
@@ -150,11 +147,12 @@ static NSDictionary *fileTransferProfileDict;
 }
 
 
-+ (IOReturn)removeService:(BluetoothSDPServiceRecordHandle)handle
++ (IOReturn)removeService:(IOBluetoothSDPServiceRecord *)serviceRecord
 {
-    // TODO: We should switch to using [IOBluetoothSDPServiceRecord removeServiceRecord]
-    // but we don't know how to get an IOBluetoothSDPServiceRecord instance from a handle.
-	return IOBluetoothRemoveServiceWithRecordHandle(handle);
+	IOReturn status = [serviceRecord removeServiceRecord];
+    serviceRecord = nil;
+	
+	return status;
 }
 
 @end

--- a/macos/_bluetoothsockets.py
+++ b/macos/_bluetoothsockets.py
@@ -57,13 +57,13 @@ def _getavailableport(proto):
 
     if proto == _lightbluecommon.RFCOMM:
         try:
-            result, channelID, servicerecordhandle = BBServiceAdvertiser.addRFCOMMServiceDictionary_withName_UUID_channelID_serviceRecordHandle_(BBServiceAdvertiser.serialPortProfileDictionary(), "DummyService", None, None, None)
+            result, channelID, servicerecord = BBServiceAdvertiser.addRFCOMMServiceDictionary_withName_UUID_channelID_serviceRecord_(BBServiceAdvertiser.serialPortProfileDictionary(), "DummyService", None, None, None)
         except:
-            result, channelID, servicerecordhandle = BBServiceAdvertiser.addRFCOMMServiceDictionary_withName_UUID_channelID_serviceRecordHandle_(BBServiceAdvertiser.serialPortProfileDictionary(), "DummyService", None)
+            result, channelID, servicerecord = BBServiceAdvertiser.addRFCOMMServiceDictionary_withName_UUID_channelID_serviceRecord_(BBServiceAdvertiser.serialPortProfileDictionary(), "DummyService", None)
         if result != _macutil.kIOReturnSuccess:
             raise _lightbluecommon.BluetoothError(result, \
                 "Could not retrieve an available service channel")
-        result = BBServiceAdvertiser.removeService_(servicerecordhandle)
+        result = BBServiceAdvertiser.removeService_(servicerecord)
         if result != _macutil.kIOReturnSuccess:
             raise _lightbluecommon.BluetoothError(result, \
                 "Could not retrieve an available service channel")

--- a/macos/_lightblue.py
+++ b/macos/_lightblue.py
@@ -45,7 +45,7 @@ __advertised = {}
 
 def finddevices(getnames=True, length=10):
     inquiry = _SyncDeviceInquiry()
-    inquiry.run(getnames, length)
+    inquiry.run(False, length)
     devices = inquiry.getfounddevices()
     return devices
 

--- a/macos/_macutil.py
+++ b/macos/_macutil.py
@@ -65,7 +65,7 @@ def formatdevaddr(addr):
     # addresses
     # can safely encode to ascii cos BT addresses are only in hex (pyobjc
     # returns all strings in unicode)
-    return addr.replace("-", ":").encode('ascii').upper()
+    return addr.replace("-", ":").upper()
 
 def createbtdevaddr(addr):
     # in mac 10.5, can use BluetoothDeviceAddress directly

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ elif sys.platform.startswith("darwin"):
             'xcodebuild', 'install',
             '-project', 'macos/LightAquaBlue/LightAquaBlue.xcodeproj',
             '-scheme', 'LightAquaBlue',
+            '-mmacosx-version-min=10.4'
             'DSTROOT=' + os.path.join(os.getcwd(), 'macos'),
             'INSTALL_PATH=/',
             'DEPLOYMENT_LOCATION=YES',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ elif sys.platform.startswith("darwin"):
             'xcodebuild', 'install',
             '-project', 'macos/LightAquaBlue/LightAquaBlue.xcodeproj',
             '-scheme', 'LightAquaBlue',
-            '-mmacosx-version-min=10.4'
+            '-mmacosx-version-min=10.4',
             'DSTROOT=' + os.path.join(os.getcwd(), 'macos'),
             'INSTALL_PATH=/',
             'DEPLOYMENT_LOCATION=YES',

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ elif sys.platform.startswith("darwin"):
             'xcodebuild', 'install',
             '-project', 'macos/LightAquaBlue/LightAquaBlue.xcodeproj',
             '-scheme', 'LightAquaBlue',
-            '-mmacosx-version-min=10.4',
+            '-mmacosx-version-min=10.10',
             'DSTROOT=' + os.path.join(os.getcwd(), 'macos'),
             'INSTALL_PATH=/',
             'DEPLOYMENT_LOCATION=YES',

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,9 @@ elif sys.platform.startswith("darwin"):
         
         # We can't seem to list a directory as package_data, so we will
         # recursively add all all files we find
+        # unfortionately symlinks don't work in wheels so the hack is to copy those as files
         package_data['lightblue'] = []
-        for path, _, files in os.walk('macos/LightAquaBlue.framework'):
+        for path, _, files in os.walk('macos/LightAquaBlue.framework', followlinks=True):
             for f in files:
                 include = os.path.join(path, f)[6:]  # trim off macos/
                 package_data['lightblue'].append(include)


### PR DESCRIPTION
 * remove deprecated api calls
 * copy symlinks for wheel

i couldn't test the bind() function on osx, but at least code is compiling again.
Also i added 3.9 as a target because 3.9 offers native bt sockets on windows (true portability - yay!) :)