### PR TITLE
fix compilation on mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/macos/LightAquaBlue/BBServiceAdvertiser.m
+++ b/macos/LightAquaBlue/BBServiceAdvertiser.m
@@ -154,7 +154,7 @@ static NSDictionary *fileTransferProfileDict;
 {
     // TODO: We should switch to using [IOBluetoothSDPServiceRecord removeServiceRecord]
     // but we don't know how to get an IOBluetoothSDPServiceRecord instance from a handle.
-	return IOBluetoothRemoveServiceWithRecordHandle(handle);
+	return [self, IOBluetoothRemoveServiceWithRecordHandle:handle];
 }
 
 @end

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ elif sys.platform.startswith("darwin"):
         # We can't seem to list a directory as package_data, so we will
         # recursively add all all files we find
         package_data['lightblue'] = []
-        for path, _, files in os.walk('macos/LightAquaBlue.framework'):
+        for path, _, files in os.walk('macos/LightAquaBlue.framework', followlinks=True):
             for f in files:
                 include = os.path.join(path, f)[6:]  # trim off macos/
                 package_data['lightblue'].append(include)


### PR DESCRIPTION
This is the minimal version for this fix. I think we should provide an easy installation path at least.
The trade off is a few redundant files vs. non-existing wheels for os x.

Contents:
 * raise python versions in action matrix
 * remove "implicit" compile error
 * copy symlinks as files for osx wheel