### PR TITLE
pypi Workflow upload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish distribution package to Test PyPI
-        if: ${{ github.repository == "pybluez/pybluez" }}
+        if: github.repository == 'pybluez/pybluez'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish distribution package to Test PyPI
-        if: github.repository == 'pybluez/pybluez'
+        if: github.event_name == 'push' && github.repository == 'pybluez/pybluez'
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish distribution package to Test PyPI
-        if: github.repository == "pybluez/pybluez"
+        if: ${{ github.repository == "pybluez/pybluez" }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish distribution package to Test PyPI
-        if: ${{ secrets.pypi_password }}
+        if: github.repository == "pybluez/pybluez"
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           name: dist
           path: dist
       - name: Publish distribution package to Test PyPI
+        if: ${{ secrets.pypi_password }}
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.test_pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,16 +42,6 @@ jobs:
       with:
         name: dist
         path: dist
-    - name: Publish distribution package to Test PyPI
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.test_pypi_password }}
-        repository_url: https://test.pypi.org/legacy/
-    - name: Publish distribution package to PyPI
-      if: startsWith(github.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@master
-      with:
-        password: ${{ secrets.pypi_password }}
 
   package_source:
     runs-on: ubuntu-latest
@@ -68,3 +58,13 @@ jobs:
         with:
           name: dist
           path: dist
+      - name: Publish distribution package to Test PyPI
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.test_pypi_password }}
+          repository_url: https://test.pypi.org/legacy/
+      - name: Publish distribution package to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -42,6 +42,16 @@ jobs:
       with:
         name: dist
         path: dist
+    - name: Publish distribution package to Test PyPI
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.test_pypi_password }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution package to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@master
+      with:
+        password: ${{ secrets.pypi_password }}
 
   package_source:
     runs-on: ubuntu-latest


### PR DESCRIPTION
this adds a task to github workflow which uploads to pypi on new tags and to pypi test on master branch commits.

i followed: https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

the following is left for the package owners to do:


- Go to https://pypi.org/manage/account/#api-tokens and create a new API token. If you have the project on PyPI already, limit the token scope to just that project. You can call it something like GitHub Actions CI/CD — project-org/project-repo in order for it to be easily distinguishable in the token list. Don’t close the page just yet — you won’t see that token again.

- In a separate browser tab or window, go to the Settings tab of your target repository and then click on Secrets in the left sidebar.

- Create a new secret called pypi_password and copy-paste the token from the fist step.

- Now, go to https://test.pypi.org/manage/account/#api-tokens and repeat the steps. Save that TestPyPI token on GitHub as test_pypi_password.
