### PR TITLE
Force installation only via wheels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+macos/LightAquaBlue.framework/
 *.o
 *.so
 *.pyc

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -38,7 +38,7 @@ or download the latest version using the links below.
 Extract the zip or tar and cd to the extracted file directory, then:
 ::
 
-	python setup.py install
+	pip install .
 
 for Bluetooth Low Energy support (GNU/Linux only):
 ::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -43,7 +43,7 @@ Extract the zip or tar and cd to the extracted file directory, then:
 for Bluetooth Low Energy support (GNU/Linux only):
 ::
 
-    pip install -e .[ble]
+    pip install .[ble]
 
 GNU/Linux Dependencies
 """"""""""""""""""""""

--- a/setup.py
+++ b/setup.py
@@ -4,20 +4,14 @@ import platform
 import sys
 
 from setuptools import setup, Extension
-
+from setuptools.dist import Distribution
 
 # This marks the wheel as always being platform-specific and not pure Python
-# See: https://stackoverflow.com/q/45150304/145504
-try:
-    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-    class impure_bdist_wheel(_bdist_wheel):
-        def finalize_options(self):
-            _bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-except ImportError:
-    # If the wheel module isn't available, no problem -- we're not doing a
-    # bdist_wheel in that case anyway.
-    impure_bdist_wheel = None
+# See: https://stackoverflow.com/a/62668026
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name"""
+    def has_ext_modules(self):
+        return True
 
 
 packages = ['bluetooth']
@@ -132,5 +126,5 @@ setup(name='PyBluez',
       package_data=package_data,
       eager_resources=eager_resources,
       zip_safe=zip_safe,
-      cmdclass={'bdist_wheel': impure_bdist_wheel},
+      distclass=BinaryDistribution,
 )

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,15 @@ from setuptools.dist import Distribution
 class BinaryDistribution(Distribution):
     """Distribution which always forces a binary package with platform name"""
     def has_ext_modules(self):
+        """We always have external modules"""
         return True
+
+    def run_command(self, command):
+        """patched to disallow the install without having built lightblue on osx"""
+        if command == "install" and sys.platform.startswith("darwin"):
+            if not self.package_data.get("lightblue"):
+                raise RuntimeError("Build wheel first")
+        return super(BinaryDistribution, self).run_command(command)
 
 
 packages = ['bluetooth']


### PR DESCRIPTION
  - original issue #378 
  - the true problem #379

tldr: pip may think installation "succeeds" even when required extensions are not actually built (because #379 ) and then trying to actually use the library will fail, this makes sure the installation actually fails if wheels (with the extensions) cannot be built.