### PR TITLE
msbt: Correct more partial LPSTR to LPWSTR migrations.

### DIFF
--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -633,7 +633,7 @@ msbt_find_service(PyObject *self, PyObject *args)
     qs->dwNumberOfCsAddrs = 0;
     qs->lpszContext = localAddressBuf;
 
-    if( 0 == wcscmp( localAddressBuf, L"localhost" ) ) {
+    if( 0 == wcscmp( addrwstr, L"localhost" ) ) {
         // find the Bluetooth address of the first local adapter. 
 #if 0
         HANDLE rhandle = NULL;
@@ -660,7 +660,7 @@ msbt_find_service(PyObject *self, PyObject *args)
         // bind a temporary socket and get its Bluetooth address
         SOCKADDR_BTH sa = { 0 };
         int sa_len = sizeof(sa);
-        int tmpfd = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM);
+        SOCKET tmpfd = socket(AF_BTH, SOCK_STREAM, BTHPROTO_RFCOMM);
 
         _CHECK_OR_RAISE_WSA( tmpfd >= 0 );
         sa.addressFamily = AF_BTH;
@@ -671,7 +671,7 @@ msbt_find_service(PyObject *self, PyObject *args)
                     &sa_len ) );
 
         ba2wstr(sa.btAddr, localAddressBuf, _countof(localAddressBuf) );
-        _close(tmpfd);
+        _CHECK_OR_RAISE_WSA(NO_ERROR == closesocket(tmpfd));
 #endif
 
         flags |= LUP_RES_SERVICE;


### PR DESCRIPTION
Fixes #307.

~~This is not the end of it. We likely need to sweep through the whole _msbt.c codebase and move all LPSTR uses to LPWSTR in order to prevent issues like this from happening again.~~ I scanned through the code quickly and it seems that this is the last unconverted LPSTR usage. Let's hope that this is actually the last one.