### PR TITLE
Fix #406 - BLE dependencies dead link

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,7 +17,7 @@ Open a terminal (command prompt on Windows) and enter
 
 For experimental Bluetooth Low Energy support (only for Linux platform -
 for additional dependencies please take look at:
-`ble-dependencies <https://bitbucket.org/OscarAcena/pygattlib/src/45e04060881a20189412681f52d55ff5add9f388/DEPENDS?at=default>`_)
+`ble-dependencies <https://github.com/oscaracena/pygattlib/blob/master/DEPENDS>`_)
 ::
 
     pip install pybluez[ble]


### PR DESCRIPTION
Changed BLE dependencies link at the installation page in docs.