### PR TITLE
Use Py_ssize_t when parsing buffer length, fix #426

### DIFF
--- a/msbt/_msbt.c
+++ b/msbt/_msbt.c
@@ -2,6 +2,8 @@
 #define UNICODE
 #endif
 
+#define PY_SSIZE_T_CLEAN 1
+
 #include <winsock2.h>
 #include <ws2bth.h>
 #include <BluetoothAPIs.h>
@@ -181,7 +183,7 @@ static PyObject *
 msbt_bind(PyObject *self, PyObject *args)
 {
     wchar_t *addrstr = NULL;
-    int addrstrlen = -1;
+    Py_ssize_t addrstrlen = -1;
     int sockfd = -1;
     int port = -1;
     char buf[100] = { 0 };
@@ -795,7 +797,7 @@ msbt_set_service_raw(PyObject *self, PyObject *args)
     WSAESETSERVICEOP op;
 
     char *record = NULL;
-    int reclen = -1;
+    Py_ssize_t reclen = -1;
     BTH_SET_SERVICE *si = NULL;
     int silen = -1;
     ULONG sdpVersion = BTH_SDP_VERSION;


### PR DESCRIPTION
From python 3.9 documentation:

> For all # variants of formats (s#, y#, etc.), the macro
> PY_SSIZE_T_CLEAN must be defined before including Python.h. On Python
> 3.9 and older, the type of the length argument is Py_ssize_t if the
> PY_SSIZE_T_CLEAN macro is defined, or int otherwise.

From python 3.8 changes:

> Use of # variants of formats in parsing or building value (e.g.
> PyArg_ParseTuple(), Py_BuildValue(), PyObject_CallFunction(), etc.)
> without PY_SSIZE_T_CLEAN defined raises DeprecationWarning now. It
> will be removed in 3.10 or 4.0. Read Parsing arguments and building
> values for detail. (Contributed by Inada Naoki in bpo-36381.)

Fixes https://github.com/pybluez/pybluez/issues/426

Tested on debian 11 with python 3.9.