### PR TITLE
Fix MacOS Tests by removing call to IOBluetoothRemoveServiceWithRecordHandle

### DIFF
--- a/macos/LightAquaBlue/BBServiceAdvertiser.m
+++ b/macos/LightAquaBlue/BBServiceAdvertiser.m
@@ -152,9 +152,9 @@ static NSDictionary *fileTransferProfileDict;
 
 + (IOReturn)removeService:(BluetoothSDPServiceRecordHandle)handle
 {
-    // TODO: We should switch to using [IOBluetoothSDPServiceRecord removeServiceRecord]
-    // but we don't know how to get an IOBluetoothSDPServiceRecord instance from a handle.
-	return IOBluetoothRemoveServiceWithRecordHandle(handle);
+
+	IOBluetoothSDPServiceRecord* record = [[IOBluetoothSDPServiceRecord withSDPServiceRecordRef:handle] removeServiceRecord];
+	return [record removeServiceRecord];
 }
 
 @end


### PR DESCRIPTION
IOBluetoothRemoveServiceWithRecordHandle is [no longer available](http://codeworkshop.net/objc-diff/sdkdiffs/macos/10.15/IOBluetooth.html) as of MacOS 10.15 which has been causing the test runner to break when attempting to compile MacOS versions of PyBluez. 

This PR implements the change proposed by @JuliusNmn [here](https://github.com/JuliusNmn/lightblue-0.4/commit/dd33161c0781541439126bb2cb7454c90ef2c219) in order to resolve this error.