### PR TITLE
Fixed string concat bug in example.

### DIFF
--- a/examples/simple/l2capserver.py
+++ b/examples/simple/l2capserver.py
@@ -26,7 +26,7 @@ data = client_sock.recv(1024)
 print("Data received:", str(data))
 
 while data:
-    client_sock.send("Echo =>", str(data))
+    client_sock.send("Echo => " + str(data))
     data = client_sock.recv(1024)
     print("Data received:", str(data))
 


### PR DESCRIPTION
Without this patch the following error occurs:

```
$ python l2capserver.py
server_sock <bluetooth.bluez.BluetoothSocket object at 0xb6714690>
Accepted connection from ('XX:XX:XX:XX:XX:XX', 4097)
Data received: b'hello it is me'
Traceback (most recent call last):
  File "l2capserver.py", line 31, in <module>
    client_sock.send("Echo =>", str(data))
  File "<string>", line 3, in send
TypeError: an integer is required (got type str)
```