### PR TITLE
Remove deprecated function call in macOS library

### DIFF
--- a/macos/LightAquaBlue/BBServiceAdvertiser.m
+++ b/macos/LightAquaBlue/BBServiceAdvertiser.m
@@ -154,7 +154,11 @@ static NSDictionary *fileTransferProfileDict;
 {
     // TODO: We should switch to using [IOBluetoothSDPServiceRecord removeServiceRecord]
     // but we don't know how to get an IOBluetoothSDPServiceRecord instance from a handle.
-	return IOBluetoothRemoveServiceWithRecordHandle(handle);
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 1050
+    return kIOReturnUnsupported;
+#else
+    return IOBluetoothRemoveServiceWithRecordHandle(handle);
+#endif
 }
 
 @end


### PR DESCRIPTION
pybluez currently does not build on recent versions of macOS (see issues #285 + #377 + #378 + #379 and PRs #381 + #428).

This PR introduces are very simple workaround floating around in the mentioned issues/PRs that removes the deprecated function call on versions of macOS where this function is no longer available.