### PR TITLE
Remove end of life Python versions and add newer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
         os: [macOS-latest, ubuntu-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
@@ -18,9 +18,6 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Windows 10 SDK for Python 3.5
-      if: startsWith(matrix.os, 'windows-') && matrix.python-version == 3.5
-      run: choco install windows-sdk-10.0
     - name: Install Linux dependencies
       if: startsWith(matrix.os, 'ubuntu-')
       run: |


### PR DESCRIPTION
Remove Python 3.5 and 3.6 from GitHub workflow as they are end of life and seem to be no longer available (and therefore cause tests to fail). Also add newer Python versions 3.9 and 3.10