### PR TITLE
Use bytes to represent filter in bluez, fix #317

### DIFF
--- a/bluez/btmodule.c
+++ b/bluez/btmodule.c
@@ -2272,14 +2272,14 @@ static PyObject * bt_hci_filter_ ## name (PyObject *self, PyObject *args )\
     char *param; \
     Py_ssize_t len; \
     int arg; \
-    if( !PyArg_ParseTuple(args,"s#i", &param, &len, &arg) ) \
+    if( !PyArg_ParseTuple(args,"y#i", &param, &len, &arg) ) \
         return 0; \
     if( len != sizeof(struct hci_filter) ) { \
         PyErr_SetString(PyExc_ValueError, "bad filter"); \
         return 0; \
     } \
     hci_filter_ ## name ( arg, (struct hci_filter*)param ); \
-    return PyUnicode_FromStringAndSize(param, len); \
+    return PyBytes_FromStringAndSize(param, len); \
 } \
 PyDoc_STRVAR(bt_hci_filter_ ## name ## _doc, docstring);
 
@@ -2301,14 +2301,14 @@ static PyObject * bt_hci_filter_ ## name (PyObject *self, PyObject *args )\
 { \
     char *param; \
     Py_ssize_t len; \
-    if( !PyArg_ParseTuple(args,"s#", &param, &len) ) \
+    if( !PyArg_ParseTuple(args,"y#", &param, &len) ) \
         return 0; \
     if( len != sizeof(struct hci_filter) ) { \
        PyErr_SetString(PyExc_ValueError, "bad filter"); \
         return 0; \
     } \
     hci_filter_ ## name ( (struct hci_filter*)param ); \
-    return PyUnicode_FromStringAndSize(param, len); \
+    return PyBytes_FromStringAndSize(param, len); \
 } \
 PyDoc_STRVAR(bt_hci_filter_ ## name ## _doc, docstring);
 
@@ -2549,7 +2549,7 @@ bt_hci_filter_new(PyObject *self, PyObject *args)
     struct hci_filter flt;
     int len = sizeof(flt);
     hci_filter_clear( &flt );
-    return Py_BuildValue("s#", (char*)&flt, len);
+    return Py_BuildValue("y#", (char*)&flt, len);
 }
 PyDoc_STRVAR(bt_hci_filter_new_doc,
 "hci_filter_new()\n\


### PR DESCRIPTION
I try to use [beacontools](https://github.com/citruz/beacontools) to scan for Eddystone beacons, but encountered exact the same problem as in issue #317.

Another possible byte vs. unicode issue in bluez bindings I spot is function `hci_send_cmd()`. Its paramter `params` need to passed as bytes produced by `struct` module, but parsed as string (`s#`). Considering possible usage regressions it might bring, I didn't put its fix in this PR.