### PR TITLE
Use PyBytes_FromStringAndSize because it may not always be interprete…

### DIFF
--- a/bluez/btmodule.c
+++ b/bluez/btmodule.c
@@ -2052,7 +2052,7 @@ bt_hci_send_req(PyObject *self, PyObject *args, PyObject *kwds)
 
     if( err< 0 ) return socko->errorhandler();
 
-    return PyUnicode_FromStringAndSize(rparam, req.rlen);
+    return PyBytes_FromStringAndSize(rparam, req.rlen);
 }
 PyDoc_STRVAR(bt_hci_send_req_doc,
 "hci_send_req(sock, ogf, ocf, event, rlen, params=None, timeout=0)\n\


### PR DESCRIPTION
rparam may not always be interpreted as Unicode, so use hci_send_req() should return PyBytes_FromStringAndSize().