### PR TITLE
Fixed the __init__ file in bluetooth folder.

### DIFF
--- a/bluetooth/__init__.py
+++ b/bluetooth/__init__.py
@@ -1,6 +1,6 @@
 import sys
 import os
-from bluetooth.btcommon import *
+from btcommon import *
 
 __version__ = 0.30
 


### PR DESCRIPTION
The Bluetooth folder's __init__ file import the btcommon file in the following way
```
import bluetooth.btcommon
```

This didn't work on my system, but the following version did

```
import btcommon
```