### PR TITLE
Suggest built-in socket module as alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Consider some alternatives:
 
+  - [Python Sockets](https://docs.python.org/3/library/socket.html): The built-in `socket` module supports (classic) Bluetooth connections at least since version 3.4
   - [Bleak](https://github.com/hbldh/bleak): Cross-platform Bluetooth Low Energy client library
   - [Bless](https://github.com/kevincar/bless): Cross-platform Bluetooth Low Energy server library
   - [PyQt](https://www.riverbankcomputing.com/software/pyqt/): Python bindings for cross-platform [QtBluetooth](https://www.riverbankcomputing.com/static/Docs/PyQt6/api/qtbluetooth/qtbluetooth-module.html) API


### PR DESCRIPTION
This adds the built-in `socket` module to the list of alternatives for classic (non-BLE) Bluetooth connections. It took me quite some time to realize that this is now possible without an external library.